### PR TITLE
Fix wording for Miao ESD protection description

### DIFF
--- a/content/miao/guide/index.md
+++ b/content/miao/guide/index.md
@@ -49,7 +49,7 @@ SUBSYSTEMS=="usb", ATTRS{idVendor}=="4348", ATTRS{idProduct}=="55e0", GROUP="uuc
 
 ## ESD protection
 
-To avoid acidentially shocking your Miao while plugging it in theres an onboard ESD protection to ensure longevity!
+To avoid accidentally shocking your Miao while plugging it in there's an onboard ESD protection circuit to ensure longevity!
 
 ## Split capability
 

--- a/content/miao/guide/index.md
+++ b/content/miao/guide/index.md
@@ -49,7 +49,7 @@ SUBSYSTEMS=="usb", ATTRS{idVendor}=="4348", ATTRS{idProduct}=="55e0", GROUP="uuc
 
 ## ESD protection
 
-To avoid accidentally shocking your Miao while plugging it in there's an onboard ESD protection circuit to ensure longevity!
+To avoid accidentally shocking your Miao while plugging it in, there's an onboard ESD protection circuit to ensure longevity!
 
 ## Split capability
 


### PR DESCRIPTION
The original wording of the ESD protection description has one misspelled word and a missing apostrophe.

I took the liberty of adding the word "circuit", but removing the `an` indicating a specific item would also make the sentence make more sense grammatically.

> To avoid accidentally shocking your Miao while plugging it in there's onboard ESD protection to ensure longevity!